### PR TITLE
Fix Palantir Location - NYC -> Washington, D.C.

### DIFF
--- a/.github/scripts/listings.json
+++ b/.github/scripts/listings.json
@@ -3552,7 +3552,7 @@
         "date_updated": 1751391357,
         "url": "https://jobs.lever.co/palantir/f17e98d0-046a-4e6e-9d65-ed0b12dd0ff7",
         "locations": [
-            "New York, NY"
+            "Washington, D.C."
         ],
         "sponsorship": "U.S. Citizenship is Required",
         "active": true,


### PR DESCRIPTION
Making a fix for [Issue: Palantir SWE (Defense Tech) location issue #3988](https://github.com/vanshb03/Summer2026-Internships/issues/3988).
 