### PR TITLE
Update WorldQuant SWE Role to Fall

### DIFF
--- a/.github/scripts/listings.json
+++ b/.github/scripts/listings.json
@@ -2693,7 +2693,7 @@
         "active": true,
         "company_name": "WorldQuant",
         "title": "Software Engineer Intern, AI/LLM Initiative",
-        "season": "Summer",
+        "season": "Fall",
         "source": "vanshb03",
         "id": "aff5ef46-63cf-4378-92a7-202fb2c2ee07",
         "date_posted": 1749595407,


### PR DESCRIPTION
WorldQuant role description states that it begins in August 2025 and lasts 4-6 months.

Resolves #4000 