### PR TITLE
[REQUEST] Update Application Links for Chicago Trading Company

### DIFF
--- a/.github/scripts/listings.json
+++ b/.github/scripts/listings.json
@@ -4753,14 +4753,14 @@
     },
     {
         "date_updated": 1752526536,
-        "url": "https://job-boards.greenhouse.io/ctccampusboard/jobs/4545359005",
+        "url": "https://grnh.se/p32j1zwl5us",
         "locations": [
             "Chicago, IL",
             "New York, NY"
         ],
         "sponsorship": "Other",
         "active": true,
-        "company_name": "CTC",
+        "company_name": "Chicago Trading Company",
         "title": "Software Engineer Intern",
         "source": "vanshb03",
         "id": "9465616f-b882-4a6b-ad84-14b011ede204",
@@ -4771,13 +4771,13 @@
     },
     {
         "date_updated": 1752526651,
-        "url": "https://job-boards.greenhouse.io/ctccampusboard/jobs/4543280005",
+        "url": "hhttps://grnh.se/rw14eooo5us",
         "locations": [
             "Chicago, IL"
         ],
         "sponsorship": "Other",
         "active": true,
-        "company_name": "CTC",
+        "company_name": "Chicago Trading Company",
         "title": "Quant Trading Intern",
         "source": "vanshb03",
         "id": "331e247c-58b7-4bb0-b517-1ad2bfc08282",


### PR DESCRIPTION
Update application links for both CTC's SE and QT roles as requested by @pmorse01 in https://github.com/vanshb03/Summer2026-Internships/issues/4028.
